### PR TITLE
Test me branch

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/SonarSource/cirrus-modules@v2", "load_features")
+load("github.com/SonarSource/cirrus-modules@feat/me/BUILD-3894", "load_features")
 
 def main(ctx):
   return load_features(ctx)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sonar-dummy-oss
 
-A sample project used for testing purpose.
+A sample project used for testing purpose. a
 
 This project use **gradle** and **is published on maven central**.
 


### PR DESCRIPTION
# 

## How was it tested ?

* replace @v2 with @me/branch

In the debug log of the build I can see:
```


INFO \|lib::load_features\|loading feature 'build_number'\|{}
--
8 | INFO \|build_number::generate_build_number\|metadata store value: '5082'\|{"env_name": "CI_BUILD_NUMBER"}
9 | INFO \|build_number::generate_build_number\|new build_number: '5083'\|{"skip_gcf_lookup": False, "build_number_raw": "5082", "env_name": "CI_BUILD_NUMBER"}
10 | INFO \|build_number::generate_build_number\|set_metadata return value: '5083'\|{"env_name": "CI_BUILD_NUMBER"}


```

Means:
1) the new feature was loaded successfully
2) it detected that the repo was not yet migrated to cirrus built-in
3) it migrated the repo to use built-in numbers
4) it provided a build number 5083

5) this build number is then used for the artifact as we can see in the build action logs:
```
[pool-6-thread-1] Deploying artifact: HIDDEN-BY-CIRRUS-CI/sonarsource-public-qa/org/sonarsource/dummy/sonar-dummy-oss-plugin/2.6.0.5083/sonar-dummy-oss-plugin-2.6.0.5083-cyclonedx.json
[pool-6-thread-1] Deploying artifact: HIDDEN-BY-CIRRUS-CI/sonarsource-public-qa/org/sonarsource/dummy/sonar-dummy-oss-plugin/2.6.0.5083/sonar-dummy-oss-plugin-2.6.0.5083-javadoc.jar
[pool-6-thread-1] Deploying artifact: HIDDEN-BY-CIRRUS-CI/sonarsource-public-qa/org/sonarsource/dummy/sonar-dummy-oss-plugin/2.6.0.5083/sonar-dummy-oss-plugin-2.6.0.5083-sources.jar
[pool-6-thread-1] Deploying artifact: HIDDEN-BY-CIRRUS-CI/sonarsource-public-qa/org/sonarsource/dummy/sonar-dummy-oss-plugin/2.6.0.5083/sonar-dummy-oss-plugin-2.6.0.5083.jar
[pool-6-thread-1] Deploying artifact: HIDDEN-BY-CIRRUS-CI/sonarsource-public-qa/org/sonarsource/dummy/sonar-dummy-oss-plugin/2.6.0.5083/sonar-dummy-oss-plugin-2.6.0.5083.module
[pool-6-thread-1] Deploying artifact: HIDDEN-BY-CIRRUS-CI/sonarsource-public-qa/org/sonarsource/dummy/sonar-dummy-oss-plugin/2.6.0.5083/sonar-dummy-oss-plugin-2.6.0.5083.pom

> Task :artifactoryDeploy
Caching disabled for task ':artifactoryDeploy' because:
  Build cache is disabled
Task ':artifactoryDeploy' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
Deploying build info...
Build-info successfully deployed. Browse it in Artifactory under HIDDEN-BY-CIRRUS-CI/webapp/builds/sonar-dummy-oss/5083
```