### PR TITLE
BUILD-4036 automate javadoc deployment (test)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,8 +64,8 @@ promote_task:
     - build
   eks_container:
     <<: *CONTAINER_DEFINITION
-    cpu: 0.5
-    memory: 500M
+    cpu: 2
+    memory: 2G
   env:
     ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
     GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,9 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@76b6e78551a9c02c9ab0506bd7e8559f138cc1e8 # 5.1.4
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@feature/svermeille/BUILD-4036-Automate-javadoc-deployment
     with:
       publishToBinaries: true
+      publishJavadoc: true
       mavenCentralSync: true
       slackChannel: team-release-engineering-notifs

--- a/.github/workflows/release_dry_run.yml
+++ b/.github/workflows/release_dry_run.yml
@@ -10,8 +10,9 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@76b6e78551a9c02c9ab0506bd7e8559f138cc1e8 # 5.1.4
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@feature/svermeille/BUILD-4036-Automate-javadoc-deployment
     with:
       dryRun: true
+      publishJavadoc: true
       publishToBinaries: true
       mavenCentralSync: true


### PR DESCRIPTION
# BUILD-4036 automate javadoc deployment (test)

## Changes
* Target custom release branch 
  That way I can test my changes in gh-action_release https://github.com/SonarSource/gh-action_release/pull/117
* Increase CPU and memory for promote task as it ended with OOKiller exception error
  That way the CI run correctly and stay stable