### PR TITLE
BUILD-3093 Enforce pre-commit at CI level

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,12 @@
+---
+on:
+  pull_request:
+
+jobs:
+  pre-commit:
+    name: "pre-commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/gh-action_pre-commit@0b086cbd326101c914f813f7d5790b8247d60f6c # 0.0.1
+        with:
+          extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref }} --to-ref=${{ github.event.pull_request.head.sha }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     rev: 9cce2940414e9560ae4c8518ddaee2ac1863a4d2  # frozen: v1.28.0
     hooks:
       - id: yamllint
-        args: [-d, "{extends: default, rules: {line-length: {max: 130}}}"]
+        args: [-d, "{extends: default, rules: {line-length: {max: 140}}}"]
   - repo: https://github.com/markdownlint/markdownlint
     rev: 4089e11ea61317283a50455ff73afe895b9d8b2d  # frozen: v0.11.0
     hooks:


### PR DESCRIPTION
# BUILD-3093 Enforce pre-commit at CI level

## Changes
* Create a pre-commit workflow to enforce pre-commit checks at CI level
* Add pre-commit check in repository's merge check

That way no one can accidentally merge changes not following it