### PR TITLE
BUILD-8714 authenticate with Repox

### DIFF
--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -19,4 +19,4 @@ jobs:
     steps:
       - uses: SonarSource/gh-action_releasability/releasability-status@48220006021661f66278901a369cfede25b1d458 # 2.2.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/build.gradle
+++ b/build.gradle
@@ -40,19 +40,14 @@ allprojects {
     def signingPassword = findProperty("signingPassword")
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     required {
-      def branch = System.getenv()["CIRRUS_BRANCH"]
-      return (branch == 'master' || branch ==~ 'branch-[\\d.]+') &&
-        gradle.taskGraph.hasTask(":artifactoryPublish")
+      return gradle.taskGraph.hasTask(":artifactoryPublish")
     }
     sign publishing.publications
   }
 
   tasks.withType(Sign) {
     onlyIf {
-      def branch = System.getenv()["CIRRUS_BRANCH"]
-      return !artifactoryPublish.skip &&
-        (branch == 'master' || branch ==~ 'branch-[\\d.]+') &&
-        gradle.taskGraph.hasTask(":artifactoryPublish")
+      return !artifactoryPublish.skip && gradle.taskGraph.hasTask(":artifactoryPublish")
     }
   }
 }
@@ -111,7 +106,7 @@ artifactory {
     repository {
       repoKey = System.getenv('ARTIFACTORY_DEPLOY_REPO')
       username = System.getenv('ARTIFACTORY_DEPLOY_USERNAME')
-      password = System.getenv('ARTIFACTORY_DEPLOY_PASSWORD')
+      password = System.getenv('ARTIFACTORY_DEPLOY_ACCESS_TOKEN')
     }
     defaults {
       properties = [


### PR DESCRIPTION
Use new implementation for authentication with Repox

Depends on https://github.com/SonarSource/ci-github-actions/pull/67

Fix Sonar projectKey: `SonarSource_sonar-dummy-gradle-oss`.
Remove obsolete CIRRUS_BRANCH env usage, and the test itself on the branch name.
Use the new variable name `ARTIFACTORY_DEPLOY_ACCESS_TOKEN` instead of legacy `ARTIFACTORY_DEPLOY_PASSWORD`.

Use github.token, not secrets.GITHUB_TOKEN

Test confirmed in the previous build: https://github.com/SonarSource/sonar-dummy-gradle-oss/actions/runs/17240749748
```
2025-08-26T14:10:57.5159032Z Set 'header' auth for 'maven' repository
```