### PR TITLE
BUILD-9058 reuse BUILD_NUMBER from env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,15 @@ concurrency:
 
 jobs:
   get-build-number:
+    outputs:
+      BUILD_NUMBER: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
     runs-on: sonar-xs-public
     name: Get build number
     permissions:
       id-token: write
     steps:
       - uses: SonarSource/ci-github-actions/get-build-number@master # dogfood
+        id: get-build-number
 
   build:
     runs-on: sonar-s-public
@@ -36,6 +39,8 @@ jobs:
       - name: Build, Analyze and deploy
         id: build
         uses: SonarSource/ci-github-actions/build-gradle@master # dogfood
+        env:
+          BUILD_NUMBER: ${{ needs.get-build-number.outputs.BUILD_NUMBER }}
         with:
           deploy-pull-request: true
           artifactory-reader-role: private-reader
@@ -54,6 +59,8 @@ jobs:
         with:
           version: 2025.7.12
       - uses: SonarSource/ci-github-actions/build-gradle@master # dogfood
+        env:
+          BUILD_NUMBER: ${{ needs.get-build-number.outputs.BUILD_NUMBER }}
         with:
           deploy-pull-request: false
           artifactory-reader-role: private-reader
@@ -62,6 +69,7 @@ jobs:
 
   promote:
     needs:
+      - get-build-number
       - build
       - build-windows
     runs-on: github-ubuntu-latest-s
@@ -71,5 +79,7 @@ jobs:
       contents: write
     steps:
       - uses: SonarSource/ci-github-actions/promote@master # dogfood
+        env:
+          BUILD_NUMBER: ${{ needs.get-build-number.outputs.BUILD_NUMBER }}
         with:
           promote-pull-request: true


### PR DESCRIPTION
BUILD-9058 Depends on https://github.com/SonarSource/ci-github-actions/pull/83

Similar to https://github.com/SonarSource/sonar-dummy/pull/483 but use a parent job to generate the build number.

Retrieve the BUILD_NUMBER generated during the `get-build-number` job and pass it to the other jobs.
This avoids facing the asynchronized GitHub cache issue.