### PR TITLE
BUILD-9881 test against sonarsource-qa

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,18 @@ jobs:
               echo "ERROR: steps.build.outputs.deployed is not true"
               exit 1
           fi
+      - name: QA test
+        shell: bash
+        env:
+          SONARSOURCE_REPOSITORY: sonarsource-qa
+        run: |
+          # Removing local artifacts to showcase downloading from sonarsource-qa
+          ./gradlew --stop
+          rm -rf ~/.gradle/caches/modules-2/files-2.1/org.sonarsource.sonarqube/sonar-plugin-api/
+          echo "Running QA tests against $ARTIFACTORY_URL/$SONARSOURCE_REPOSITORY..."
+          ./gradlew test --info | tee qa-test.log
+          grep "Added Repox repository at 'https://repox.jfrog.io/artifactory/sonarsource-qa'" qa-test.log
+          grep "Downloading https://repox.jfrog.io/artifactory/sonarsource-qa/org/sonarsource/sonarqube/sonar-plugin-api/" qa-test.log
 
   build-windows:
     runs-on: warp-custom-windows-2022-s


### PR DESCRIPTION
Test https://github.com/SonarSource/ci-github-actions/pull/178

Confirm download from sonarsource-qa when using `SONARSOURCE_REPOSITORY=sonarsource-qa`.

```
Running QA tests against https://repox.jfrog.io/artifactory/sonarsource-qa...
...
Added Repox repository at 'https://repox.jfrog.io/artifactory/sonarsource-qa'
Added Repox repository at 'https://repox.jfrog.io/artifactory/sonarsource-qa'
Added Repox repository at 'https://repox.jfrog.io/artifactory/sonarsource-qa'
Added Repox repository at 'https://repox.jfrog.io/artifactory/sonarsource-qa'
Downloading https://repox.jfrog.io/artifactory/sonarsource-qa/org/sonarsource/sonarqube/sonar-plugin-api/9.4.0.54424/sonar-plugin-api-9.4.0.54424.pom to /home/runner/.gradle/.tmp/gradle_download7844149448886172541bin
Downloading https://repox.jfrog.io/artifactory/sonarsource-qa/org/sonarsource/sonarqube/sonar-plugin-api/9.4.0.54424/sonar-plugin-api-9.4.0.54424.jar to /home/runner/.gradle/.tmp/gradle_download409160314437126848bin
```