### PR TITLE
BUILD-9956 downgrade Develocity plugin to 4.0.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
           deploy-pull-request: true
           artifactory-reader-role: private-reader
           artifactory-deployer-role: qa-deployer
+          use-develocity: true
           provenance: 'true'
       - name: verify build-gradle behavior
         env:
@@ -64,8 +65,7 @@ jobs:
           ./gradlew --stop
           rm -rf ~/.gradle/caches/modules-2/files-2.1/org.sonarsource.sonarqube/sonar-plugin-api/
           echo "Running QA tests against $ARTIFACTORY_URL/$SONARSOURCE_REPOSITORY..."
-          ./gradlew test --info | tee qa-test.log
-          grep "Added Repox repository at 'https://repox.jfrog.io/artifactory/sonarsource-qa'" qa-test.log
+          ./gradlew test --info --no-scan | tee qa-test.log
           grep "Downloading https://repox.jfrog.io/artifactory/sonarsource-qa/org/sonarsource/sonarqube/sonar-plugin-api/" qa-test.log
 
   build-windows:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradle.develocity" version "4.2"
+  id "com.gradle.develocity" version "4.0.3"
   id "com.gradle.common-custom-user-data-gradle-plugin" version "2.3"
 }
 


### PR DESCRIPTION
BUILD-9956

Downgrade the Develocity Gradle plugin to 4.0.3 for compliance.

```
Publishing Build Scan to Develocity...

The request was rejected.
Develocity plugin version 4.2 is newer than the newest version supported by Develocity 2025.1.3 which is 4.0. Please update to a newer version of Develocity.
```

Deactivate scan upload in the "QA test" step.
Fix the tests since the logs from Gradle init script have changed (added repositories moved to debug log level).