### PR TITLE
BUILD-9971 remove obsolete versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,6 @@ allprojects {
   apply plugin: 'maven-publish'
   apply plugin: "org.cyclonedx.bom"
 
-  // Replaces the version defined in sources, usually x.y-SNAPSHOT, by a version identifying the build.
-  def buildNumber = System.getProperty("buildNumber")
-  if (version.endsWith('-SNAPSHOT') && buildNumber != null) {
-    version = version.replace('-SNAPSHOT', ".0.$buildNumber")
-  }
-
   signing {
     def signingKeyId = findProperty("signingKeyId")
     def signingKey = findProperty("signingKey")


### PR DESCRIPTION
BUILD-9971
The version SNAPSHOT replacement with the build number is handled by https://github.com/SonarSource/ci-github-actions/tree/master/config-gradle

The code was inactive and never called. Similar setup in other project was conflicting and generating incorrect versions.