### PR TITLE
BUILD-10206 Replace deprecated SonarPlugin with Plugin interface

### DIFF
--- a/sonar-dummy-gradle-oss-plugin/src/main/java/org/sonarsource/dummy/plugin/DummyPlugin.java
+++ b/sonar-dummy-gradle-oss-plugin/src/main/java/org/sonarsource/dummy/plugin/DummyPlugin.java
@@ -18,16 +18,13 @@
  */
 package org.sonarsource.dummy.plugin;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.sonar.api.SonarPlugin;
+import org.sonar.api.Plugin;
 
-public final class DummyPlugin extends SonarPlugin {
+public final class DummyPlugin implements Plugin {
 
-  @SuppressWarnings({"rawtypes"})
   @Override
-  public List getExtensions() {
-    return new ArrayList<>();
+  public void define(Context context) {
+    // Register extensions here if needed
   }
 
 


### PR DESCRIPTION
## Summary
Replace the deprecated `SonarPlugin` class with the modern `Plugin` interface to fix SonarQube Quality Gate issue.

## Changes
- Replaced `extends SonarPlugin` with `implements Plugin`
- Updated `getExtensions()` method to `define(Context context)`
- Removed unused imports