### PR TITLE
BUILD-10274 Fix signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target/
 *.ipr
 .idea/
 .DS_Store
+.serena/

--- a/build.gradle
+++ b/build.gradle
@@ -20,15 +20,17 @@ allprojects {
   apply plugin: 'maven-publish'
   apply plugin: "org.cyclonedx.bom"
 
-  signing {
-    def signingKeyId = findProperty("signingKeyId")
-    def signingKey = findProperty("signingKey")
-    def signingPassword = findProperty("signingPassword")
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    required {
-      return gradle.taskGraph.hasTask(":artifactoryPublish")
+  afterEvaluate {
+    signing {
+      def signingKeyId = findProperty("signingKeyId")
+      def signingKey = findProperty("signingKey")
+      def signingPassword = findProperty("signingPassword")
+      useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+      required {
+        return gradle.taskGraph.hasTask(":artifactoryPublish")
+      }
+      sign publishing.publications
     }
-    sign publishing.publications
   }
 
   tasks.withType(Sign) {
@@ -42,6 +44,7 @@ subprojects {
   apply plugin: 'java'
   apply plugin: "jacoco"
   apply plugin: 'com.github.hierynomus.license'
+  apply plugin: 'signing'
 
   java {
     withJavadocJar()


### PR DESCRIPTION
The change wraps the signing { ... } block in afterEvaluate { ... } so it executes after all project configuration (including the mavenJava publication in subprojects) is complete.

This ensures that when sign publishing.publications is called, the publications actually exist and will have sign tasks created for them.