### PR TITLE
BUILD-10215 Test error annotation rendering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,9 @@ jobs:
           version: 2025.7.12
       - name: Build, Analyze and deploy
         id: build
-        uses: SonarSource/ci-github-actions/build-gradle@master # dogfood
+        uses: SonarSource/ci-github-actions/build-gradle@BUILD-10215-standardize-ghaction-output-logging
         with:
+          sonar-platform: invalid-platform
           deploy-pull-request: true
           artifactory-reader-role: private-reader
           artifactory-deployer-role: qa-deployer


### PR DESCRIPTION
## Purpose

This PR deliberately sets `sonar-platform: invalid-platform` to trigger the `::error title=Invalid Sonar platform::` annotation added in BUILD-10215.

**This is a test PR to visually verify that error annotations render correctly in the GitHub Actions UI.** The build is expected to fail.

Once verified, this PR should be closed without merging.

## What to look for

The "Build, Analyze and deploy" step should fail with a red error annotation visible at the top of the Actions run page:

> **Invalid Sonar platform**: Invalid Sonar platform 'invalid-platform'. Must be one of: next, sqc-us, sqc-eu, none

🤖 Generated with [Claude Code](https://claude.com/claude-code)