### PR TITLE
BUILD-10389 use S3 cache storage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  CACHE_BACKEND: s3
+
 jobs:
   get-build-number:
     outputs:

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -4,6 +4,9 @@ on:
     types:
       - closed
 
+env:
+  CACHE_BACKEND: s3
+
 jobs:
   cleanup:
     runs-on: sonar-xs-public

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+env:
+  CACHE_BACKEND: s3
+
 jobs:
   build:
     runs-on: github-ubuntu-latest-s


### PR DESCRIPTION
Use S3 cache storage.

Depends on https://github.com/SonarSource/gh-action_cache/pull/40
