### PR TITLE
test: BUILD-10591 dogfood feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: SonarSource/ci-github-actions/get-build-number@master # dogfood
+      - uses: SonarSource/ci-github-actions/get-build-number@feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary # dogfood
         id: get-build-number
 
   build:
@@ -44,7 +44,7 @@ jobs:
           version: 2025.7.12
       - name: Build, Analyze and deploy
         id: build
-        uses: SonarSource/ci-github-actions/build-gradle@master # dogfood
+        uses: SonarSource/ci-github-actions/build-gradle@feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary # dogfood
         with:
           deploy-pull-request: true
           artifactory-reader-role: private-reader
@@ -92,7 +92,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           version: 2025.7.12
-      - uses: SonarSource/ci-github-actions/config-gradle@master # dogfood
+      - uses: SonarSource/ci-github-actions/config-gradle@feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary # dogfood
         with:
           use-develocity: false
           artifactory-reader-role: private-reader
@@ -115,7 +115,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           version: 2025.7.12
-      - uses: SonarSource/ci-github-actions/build-gradle@master # dogfood
+      - uses: SonarSource/ci-github-actions/build-gradle@feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary # dogfood
         id: build
         with:
           deploy: false
@@ -147,6 +147,6 @@ jobs:
     env:
       BUILD_NUMBER: ${{ needs.get-build-number.outputs.BUILD_NUMBER }}
     steps:
-      - uses: SonarSource/ci-github-actions/promote@master # dogfood
+      - uses: SonarSource/ci-github-actions/promote@feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary # dogfood
         with:
           promote-pull-request: true

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: SonarSource/ci-github-actions/build-gradle@master # dogfood
+      - uses: SonarSource/ci-github-actions/build-gradle@feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary # dogfood
         with:
           run-shadow-scans: true
           artifactory-reader-role: private-reader


### PR DESCRIPTION
## Summary

- Dogfooding `feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary` from `SonarSource/ci-github-actions`
- Tests the JFrog Job Summary feature enabled by `jfrog/setup-jfrog-cli` in all build actions

## Test plan

- [ ] Verify JFrog Job Summary appears in the GitHub Actions workflow summary
- [x] Confirm build and deployment works as before

**DO NOT MERGE** — testing branch only