### PR TITLE
PREQ-4918: Test artifact-name input for matrix jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           version: 2025.7.12
       - name: Build, Analyze and deploy
         id: build
-        uses: SonarSource/ci-github-actions/build-gradle@master # dogfood
+        uses: SonarSource/ci-github-actions/build-gradle@PREQ-4918-support-unique-artifact-names-for-matrix-jobs # test PREQ-4918
         with:
           deploy-pull-request: true
           artifactory-reader-role: private-reader
@@ -115,7 +115,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           version: 2025.7.12
-      - uses: SonarSource/ci-github-actions/build-gradle@master # dogfood
+      - uses: SonarSource/ci-github-actions/build-gradle@PREQ-4918-support-unique-artifact-names-for-matrix-jobs # test PREQ-4918
         id: build
         with:
           deploy: false
@@ -133,12 +133,39 @@ jobs:
               exit 1
           fi
 
+  test-artifact-name:
+    runs-on: sonar-s-public
+    name: Test artifact-name (${{ matrix.module }})
+    permissions:
+      id-token: write
+      contents: write
+      attestations: write
+    needs: get-build-number
+    strategy:
+      matrix:
+        module: [moduleA, moduleB]
+    env:
+      BUILD_NUMBER: ${{ needs.get-build-number.outputs.BUILD_NUMBER }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
+        with:
+          version: 2025.7.12
+      - uses: SonarSource/ci-github-actions/build-gradle@PREQ-4918-support-unique-artifact-names-for-matrix-jobs # test PREQ-4918
+        with:
+          deploy: false
+          artifactory-reader-role: private-reader
+          artifactory-deployer-role: qa-deployer
+          use-develocity: true
+          artifact-name: ${{ matrix.module }}
+
   promote:
     needs:
       - get-build-number
       - build
       - build-windows
       - test-working-directory
+      - test-artifact-name
     runs-on: github-ubuntu-latest-s
     name: Promote
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,9 +133,9 @@ jobs:
               exit 1
           fi
 
-  test-artifact-name:
+  test-job-identifier-linux:
     runs-on: sonar-s-public
-    name: Test artifact-name (${{ matrix.module }})
+    name: Test job-identifier Linux (${{ matrix.module }})
     permissions:
       id-token: write
       contents: write
@@ -157,7 +157,33 @@ jobs:
           artifactory-reader-role: private-reader
           artifactory-deployer-role: qa-deployer
           use-develocity: true
-          artifact-name: ${{ matrix.module }}
+          job-identifier: ${{ matrix.module }}
+
+  test-job-identifier-windows:
+    runs-on: warp-custom-windows-2022-s
+    name: Test job-identifier Windows (${{ matrix.module }})
+    permissions:
+      id-token: write
+      contents: write
+      attestations: write
+    needs: get-build-number
+    strategy:
+      matrix:
+        module: [moduleA, moduleB]
+    env:
+      BUILD_NUMBER: ${{ needs.get-build-number.outputs.BUILD_NUMBER }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
+        with:
+          version: 2025.7.12
+      - uses: SonarSource/ci-github-actions/build-gradle@PREQ-4918-support-unique-artifact-names-for-matrix-jobs # test PREQ-4918
+        with:
+          deploy: false
+          artifactory-reader-role: private-reader
+          artifactory-deployer-role: qa-deployer
+          use-develocity: true
+          job-identifier: ${{ matrix.module }}
 
   promote:
     needs:
@@ -165,7 +191,8 @@ jobs:
       - build
       - build-windows
       - test-working-directory
-      - test-artifact-name
+      - test-job-identifier-linux
+      - test-job-identifier-windows
     runs-on: github-ubuntu-latest-s
     name: Promote
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
     needs: get-build-number
     strategy:
       matrix:
-        module: [moduleA, moduleB]
+        module: [windows-moduleA, windows-moduleB]
     env:
       BUILD_NUMBER: ${{ needs.get-build-number.outputs.BUILD_NUMBER }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
           job-identifier: ${{ matrix.module }}
 
   test-job-identifier-windows:
-    runs-on: warp-custom-windows-2022-s
+    runs-on: github-windows-latest-s
     name: Test job-identifier Windows (${{ matrix.module }})
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary

Test PR for [ci-github-actions#240](https://github.com/SonarSource/ci-github-actions/pull/240) — adds `artifact-name` input to `build-gradle` to avoid artifact name collisions in matrix jobs.

**Changes:**
- Points `build-gradle` steps to the working branch `PREQ-4918-support-unique-artifact-names-for-matrix-jobs`
- Adds `test-artifact-name` matrix job with 2 entries (`moduleA`, `moduleB`) that each pass a unique `artifact-name`, producing artifacts `problems-report-moduleA` and `problems-report-moduleB`

## Test plan

- [ ] CI passes without artifact name collision errors
- [ ] Both matrix entries (`moduleA`, `moduleB`) upload their artifacts with distinct names
- [ ] Existing `build` and `build-windows` jobs still work correctly with the new action version