### PR TITLE
Add StepSecurity Harden Runner to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,6 +147,9 @@ jobs:
     env:
       BUILD_NUMBER: ${{ needs.get-build-number.outputs.BUILD_NUMBER }}
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: SonarSource/ci-github-actions/promote@master # dogfood
         with:
           promote-pull-request: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,9 @@ jobs:
     name: "pre-commit"
     runs-on: github-ubuntu-latest-s
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: SonarSource/gh-action_pre-commit@0ecedc4e4070444a95f6b6714ddc3ebcdde697c4 # 1.1.0
         with:
           extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref }} --to-ref=${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -19,6 +19,9 @@ jobs:
       contents: read
     if: github.event.workflow_run.conclusion == 'success'
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: SonarSource/gh-action_releasability/releasability-status@v3 # v3
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -16,6 +16,9 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: SonarSource/ci-github-actions/build-gradle@master # dogfood
         with:


### PR DESCRIPTION
Adds [`step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40`](https://github.com/step-security/harden-runner) (v2.19.0) as the first step in every job running on GitHub-hosted runners, using `egress-policy: audit` to monitor outbound network traffic without blocking.

**Workflows updated:** `build.yml` (promote job), `pre-commit.yml`, `releasability.yml`, `unified-dogfooding.yml`

> Jobs on self-hosted runners (`sonar-xs-public`, `sonar-s-public`, `warp-custom-windows-2022-s`) and `release.yml` (reusable workflow call) are excluded.