### PR TITLE
BUILD-11249 Use @master for all SonarSource dogfooding actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-      - uses: SonarSource/gh-action_pre-commit@0ecedc4e4070444a95f6b6714ddc3ebcdde697c4 # 1.1.0
+      - uses: SonarSource/gh-action_pre-commit@master # dogfood
         with:
           extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref }} --to-ref=${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -22,6 +22,6 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-      - uses: SonarSource/gh-action_releasability/releasability-status@v3 # v3
+      - uses: SonarSource/gh-action_releasability/releasability-status@master # dogfood
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,22 @@
 name: Release
 
-# Trigger when publishing a new GitHub release
+# yamllint disable-line rule:truthy
 on:
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+        type: string
 
 jobs:
   release:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6 # v6
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@master # dogfood
     with:
+      version: ${{ inputs.version }}
       publishToBinaries: true
       mavenCentralSync: true
       publicRelease: true

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -26,7 +26,7 @@ jobs:
           artifactory-reader-role: private-reader
           artifactory-deployer-role: qa-deployer
       - name: Run IRIS Analysis
-        uses: SonarSource/unified-dogfooding-actions/run-iris@v1
+        uses: SonarSource/unified-dogfooding-actions/run-iris@master # dogfood
         with:
           primary_project_key: "SonarSource_sonar-dummy-gradle-oss"
           primary_platform: "SQC-EU"


### PR DESCRIPTION
## Summary

Align all SonarSource action refs to `@master` for dogfooding purposes:

- `gh-action_release`: `workflow_dispatch` trigger + required `version` input, `@v6` → `@master`
- `gh-action_pre-commit`: `1.1.0` (sha) → `@master`
- `gh-action_releasability`: `@v3` → `@master`
- `unified-dogfooding-actions/run-iris`: `@v1` → `@master`

## Test plan

- [ ] Build CI passes on this PR
- [ ] Trigger release manually via `workflow_dispatch` to validate flow