### PR TITLE
BUILD-11463 Add update-release-channel dogfood workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,17 @@ jobs:
       publicRelease: true
       publishJavadoc: true
       isDummyProject: true
+
+  update-release-channel:
+    name: Update 'latest' release channel pointer
+    needs: release
+    runs-on: sonar-xs
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: SonarSource/ci-github-actions/update-release-channel@master # dogfood
+        with:
+          version: ${{ inputs.version }}
+          channel: latest
+          product: sonar-dummy-gradle-oss-plugin

--- a/.github/workflows/update-release-channel.yml
+++ b/.github/workflows/update-release-channel.yml
@@ -1,6 +1,5 @@
 name: Update binary release channel pointer
 
-# Dogfood for SonarSource/ci-github-actions/update-release-channel (BUILD-11463).
 # After a successful dispatch, verify the written pointer at:
 #   https://binaries.sonarsource.com/?prefix=Distribution/sonar-dummy-gradle-oss-plugin/
 

--- a/.github/workflows/update-release-channel.yml
+++ b/.github/workflows/update-release-channel.yml
@@ -1,0 +1,40 @@
+name: Update release channel
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version the channel should be updated to point at (e.g. 0.9.0.977).
+        required: true
+        type: string
+      channel:
+        description: Release channel to update.
+        required: true
+        type: choice
+        options:
+          - latest
+          - stable
+          - beta
+          - rc
+      dryRun:
+        description: When true, resolve and print the planned PutObject without writing to S3.
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  update-channel:
+    name: Update ${{ inputs.channel }} channel
+    runs-on: sonar-xs
+    environment: release-channel-admin
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: SonarSource/ci-github-actions/update-release-channel@master # dogfood
+        with:
+          version: ${{ inputs.version }}
+          channel: ${{ inputs.channel }}
+          product: sonar-dummy-gradle-oss-plugin
+          dryRun: ${{ inputs.dryRun }}

--- a/.github/workflows/update-release-channel.yml
+++ b/.github/workflows/update-release-channel.yml
@@ -1,4 +1,8 @@
-name: Update release channel
+name: Update binary release channel pointer
+
+# Dogfood for SonarSource/ci-github-actions/update-release-channel (BUILD-11463).
+# After a successful dispatch, verify the written pointer at:
+#   https://binaries.sonarsource.com/?prefix=Distribution/sonar-dummy-gradle-oss-plugin/
 
 # yamllint disable-line rule:truthy
 on:
@@ -24,8 +28,8 @@ on:
         default: false
 
 jobs:
-  update-channel:
-    name: Update ${{ inputs.channel }} channel
+  update-release-channel:
+    name: Update '${{ inputs.channel }}' release channel pointer
     runs-on: sonar-xs
     environment: release-channel-admin
     permissions:


### PR DESCRIPTION
## Summary

Adds a manual `workflow_dispatch` entry point that exercises the upcoming `update-release-channel` action (from `ci-github-actions`) end-to-end against this dummy repo. The product input is overridden to `sonar-dummy-gradle-oss-plugin` because that's the actual S3 folder name — useful coverage for the `product:` override path before [BUILD-11464](https://sonarsource.atlassian.net/browse/BUILD-11464) wires the same action into `sonarqube-cli`.

Action reference is pinned to `@master` per the repo's dogfooding convention (see [BUILD-11249](https://sonarsource.atlassian.net/browse/BUILD-11249), `release.yml`, `releasability.yml`).

Tickets:
- [BUILD-11463](https://sonarsource.atlassian.net/browse/BUILD-11463) — this PR
- [BUILD-11447](https://sonarsource.atlassian.net/browse/BUILD-11447) — parent epic

## Prerequisites before first dispatch

1. **Create the `release-channel-admin` GitHub Environment** in this repo (Settings → Environments → New environment). Add required reviewers from the squad release-captain / Engineering XP allowlist. Without this, the workflow will queue indefinitely waiting for approval.
2. **The action itself must be runnable on master.** Currently being completed via [BUILD-11459](https://sonarsource.atlassian.net/browse/BUILD-11459) / [BUILD-11460](https://sonarsource.atlassian.net/browse/BUILD-11460) / [BUILD-11461](https://sonarsource.atlassian.net/browse/BUILD-11461). Until those merge, dispatches are expected to be no-ops or stub output — that's the point of dogfooding here first.

## Test plan

Post-merge, once the action is functional on `ci-github-actions/master`:

- [ ] Dispatch with `version: 0.0.0-channel-test`, `channel: rc`, `dryRun: true` — verify resolved bucket/key surface in the run log.
- [ ] Dispatch with `dryRun: false` on `rc`. Approve gate. Verify `curl -I https://binaries.sonarsource.com/Distribution/sonar-dummy-gradle-oss-plugin/rc.json` returns `Cache-Control: max-age=60`, `Content-Type: application/json`, and a body matching the v1 schema.
- [ ] Repeat for `channel: beta`. Confirm `beta.json` and `rc.json` are independent.
- [ ] Rollback smoke test: dispatch `version: 0.0.0-channel-test-2` on `rc`, then re-dispatch the original on `rc`. Confirm `rc.json` returns to the original value.
- [ ] Confirm an unapproved dispatch never writes to S3 (revoke approval or wait without approving).
- [ ] Record run URLs as evidence on [BUILD-11447](https://sonarsource.atlassian.net/browse/BUILD-11447).

[BUILD-11464]: https://sonarsource.atlassian.net/browse/BUILD-11464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11249]: https://sonarsource.atlassian.net/browse/BUILD-11249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11463]: https://sonarsource.atlassian.net/browse/BUILD-11463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11447]: https://sonarsource.atlassian.net/browse/BUILD-11447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11459]: https://sonarsource.atlassian.net/browse/BUILD-11459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ