### PR TITLE
BUILD-11460: Point dogfood workflow at fix branch for testing

### DIFF
--- a/.github/workflows/update-release-channel.yml
+++ b/.github/workflows/update-release-channel.yml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: SonarSource/ci-github-actions/update-release-channel@master # dogfood
+      - uses: SonarSource/ci-github-actions/update-release-channel@fix/jkinavoormadam/BUILD-11460-bodyTempfile # dogfood — test PR #275 before revert to @master
         with:
           version: ${{ inputs.version }}
           channel: ${{ inputs.channel }}


### PR DESCRIPTION
BUILD-11460 — companion to [SonarSource/ci-github-actions#275](https://github.com/SonarSource/ci-github-actions/pull/275).

## Why

The dogfood workflow currently fails on `@master` because of the
`--body /dev/stdin` regression: https://github.com/SonarSource/sonar-dummy-gradle-oss/actions/runs/26578122174

This PR temporarily points the action ref at the fix branch so the
dispatch workflow can validate the fix end-to-end against a real S3
PutObject before #275 merges.

## What changed

`.github/workflows/update-release-channel.yml`: pin
`SonarSource/ci-github-actions/update-release-channel` to
`@fix/jkinavoormadam/BUILD-11460-bodyTempfile` instead of `@master`.

`release.yml` is intentionally untouched — that workflow gates real
releases and should stay on `@master`.

## How to test

Run the **Update binary release channel pointer** workflow via
`workflow_dispatch` with e.g. `version=2.8.0.10015`, `channel=latest`,
`dryRun=false`, and verify it now succeeds and writes the pointer to
S3.

## Follow-up

Revert this commit (or re-merge `master`) once #275 lands so we are
back on `@master`.