### PR TITLE
BUILD-11686 Add report-ci-metrics job and move build jobs off public runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
   get-build-number:
     outputs:
       BUILD_NUMBER: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: Get build number
     permissions:
       id-token: write
@@ -28,7 +28,7 @@ jobs:
         id: get-build-number
 
   build:
-    runs-on: sonar-s-public
+    runs-on: sonar-s
     name: Build
     permissions:
       id-token: write
@@ -72,7 +72,7 @@ jobs:
           grep "Downloading https://repox.jfrog.io/artifactory/sonarsource-qa/org/sonarsource/sonarqube/sonar-plugin-api/" qa-test.log
 
   test-working-directory:
-    runs-on: sonar-s-public
+    runs-on: sonar-s
     name: Test with working-directory
     permissions:
       id-token: write
@@ -132,6 +132,20 @@ jobs:
               echo "ERROR: steps.build.outputs.deployed is true"
               exit 1
           fi
+
+  report-ci-metrics:
+    needs:
+      - build
+      - test-working-directory
+      - build-windows
+    if: always() && (github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+    runs-on: sonar-xs
+    name: Report CI metrics
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+      - uses: SonarSource/ci-github-actions/report-ci-metrics@master # dogfood
 
   promote:
     needs:


### PR DESCRIPTION
## What

Two changes to `build.yml`:

1. **Add a `report-ci-metrics` job** mirroring the one in [sonar-dummy](https://github.com/SonarSource/sonar-dummy/blob/master/.github/workflows/build.yml). Runs after `build`, `test-working-directory` and `build-windows` (`if: always()`) and posts the CI-metrics sticky PR comment / job summary via `SonarSource/ci-github-actions/report-ci-metrics@master`.
2. **Retarget the `sonar-*-public` runners to their `sonar-*` equivalents**: `sonar-xs-public` → `sonar-xs` (get-build-number, report-ci-metrics), `sonar-s-public` → `sonar-s` (build, test-working-directory). `warp-custom-windows-2022-s` and `github-ubuntu-latest-s` are unchanged.

## Why

Roll out CI-metrics dogfooding now that `report-ci-metrics` trend-display ([BUILD-11311](https://sonarsource.atlassian.net/browse/BUILD-11311)) is merged to `ci-github-actions` master and [gh-action_cache PR #87](https://github.com/SonarSource/gh-action_cache/pull/87) (BUILD-11686) fixed the cache dist to emit the snake_case JSON keys the report consumes. The runner move standardises this repo onto the internal `sonar-*` fleet.

The report action reads per-job metrics from the run's job logs via the GitHub API — no checkout, artifacts, or cache step needed; only `actions: read` + `pull-requests: write`.

## Verification

- `actionlint` clean for the changes (custom self-hosted runner-label notices are pre-existing across the file).
- `needs: [build, test-working-directory, build-windows]` matches existing job keys.

Part of BUILD-11686

[BUILD-11311]: https://sonarsource.atlassian.net/browse/BUILD-11311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **CI workflow migration:**
  - Migrated `get-build-number`, `build`, and `test-working-directory` jobs from public to internal runners by updating `runs-on` labels from `-public` to internal counterparts.

<sub>This will update automatically on new commits.</sub>