### PR TITLE
BUILD-11881 Fix artifactoryPublish failure: pin cyclonedxBom JSON output path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,8 @@ subprojects {
 
   def bomFile = layout.buildDirectory.file('reports/bom.json')
   cyclonedxBom {
+    // cyclonedx-gradle-plugin 2.x+ defaults to build/reports/cyclonedx/bom.json; pin it back explicitly.
+    jsonOutput.set(bomFile)
     outputs.file bomFile
   }
   def bomArtifact = artifacts.add('archives', bomFile.get().asFile) {


### PR DESCRIPTION
## Summary

`Build` has been failing on `master` since the `org.cyclonedx.bom` Gradle plugin was bumped (Renovate), with:

```
Caused by: org.gradle.api.GradleException: File '.../sonar-dummy-gradle-oss-plugin/build/reports/bom.json' does not exist,
and need to be published from publication mavenJava
```

`cyclonedx-gradle-plugin` 2.x+ changed the `cyclonedxBom` task's default output location from `build/reports/bom.json` to
`build/reports/cyclonedx/bom.json`. `build.gradle` only declared the *expected* task output (`outputs.file bomFile`) for
Gradle's up-to-date checking, without telling the plugin where to actually write — so the file was written to the new
default path while `artifactoryPublish` kept looking for it at the old, hardcoded path.

Fix: explicitly set `jsonOutput` on the `cyclonedxBom` task to the same `bomFile` path, so the plugin writes where the
rest of the build expects it, regardless of its own default.

## Test plan

- [x] `./gradlew :sonar-dummy-gradle-oss-plugin:cyclonedxBom` — confirmed `build/reports/bom.json` is produced at the expected path (previously only `build/reports/cyclonedx/bom.json` existed)
- [x] `./gradlew :sonar-dummy-gradle-oss-plugin:artifactoryPublish` — runs clean locally (deploy steps skip due to no local Artifactory credentials, but the previously-failing "file does not exist" step now passes)
- [ ] CI `Build` workflow passes on this PR